### PR TITLE
Fix Typo in Github Url

### DIFF
--- a/book.json
+++ b/book.json
@@ -16,7 +16,7 @@
       "label": "Edit This Page"
     },
     "github": {
-      "url": "https://github.com/MassTransit/Greenipes/"
+      "url": "https://github.com/MassTransit/GreenPipes/"
     },
     "theme-default": {
       "styles": {


### PR DESCRIPTION
The current API docs point to a wrong url.